### PR TITLE
Readme: Fix broken evil package link

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,5 +1,5 @@
 #+TITLE:Evil-avy
-[[https://bitbucket.org/lyro/evil/wiki/Home][Evil]] motions with [[https://github.com/abo-abo/avy][avy]] style.
+[[https://github.com/emacs-evil/evil][Evil]] motions with [[https://github.com/abo-abo/avy][avy]] style.
 
 Without count, motions will let you pick candidate via avy.
 


### PR DESCRIPTION
The link to the evil package leads to a page that says:
>That link has no power here
Return to the previous page or go back to your dashboard.

The evil package is hosted at:
https://github.com/emacs-evil/evil